### PR TITLE
Added metric for queued connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
+## [Unreleased] - 2016-03-03
+### Added
+- metric for a queued connections (at a state 'connecting') from @xdrus.
+
 ## [0.1.0] - 2015-07-23
 
 ### Changed

--- a/bin/metrics-strongswan.rb
+++ b/bin/metrics-strongswan.rb
@@ -49,7 +49,9 @@ class StrongswanMetrics < Sensu::Plugin::Metric::CLI::Graphite
     ipsec_status.each_line do |line|
       if line =~ /Security Associations/
         connections = ipsec_status.match(/Security Associations \((\d+)/)[1].to_i
+        queue = ipsec_status.match(/Security Associations \(.*,\s*(\d+)/)[1].to_i
         output "#{config[:scheme]}.connections", connections
+        output "#{config[:scheme]}.queue", queue
       end
       ok
     end


### PR DESCRIPTION
StrongSwan command `ipsec status` shows not only established connections, but also a number of connections in 'connecting' state (queued). I've added this metric to output because t is important to know when system is not able to handle all incoming connections.

Testing example:
![t1_micro_100ms_connections](https://cloud.githubusercontent.com/assets/6975314/13505657/4ee8afd0-e17a-11e5-998a-513e4617ea5f.png)
