### PR TITLE
fix: add a timeout on ipsec command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- check-strongswan-connection.rb: add unknown status if unable to retrieve connection status (@nishiki)
 
 ## [1.1.0] - 2018-02-22
 ### Added


### PR DESCRIPTION
## Pull Request Checklist

Hello,

I add a little fix, if ipsec command is hang we return unknow status and not a critical as currently

```
# /opt/sensu/embedded/bin/ruby check-strongswan-connection.rb -c fr-dc-pa6
CheckStrongswanConnection UNKNOWN: unable to retrieve the connection status
```
See: https://lists.strongswan.org/pipermail/users/2013-June/004802.html

Regards,

#### General

- [X] Update Changelog following the conventions laid out on [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
